### PR TITLE
excluded terminating null character and fixed content-length

### DIFF
--- a/ngx_http_hello_world_module.c
+++ b/ngx_http_hello_world_module.c
@@ -112,14 +112,14 @@ static ngx_int_t ngx_http_hello_world_handler(ngx_http_request_t *r)
     out.next = NULL; /* just one buffer */
 
     b->pos = ngx_hello_world; /* first position in memory of the data */
-    b->last = ngx_hello_world + sizeof(ngx_hello_world); /* last position in memory of the data */
+    b->last = ngx_hello_world + sizeof(ngx_hello_world)-1; /* last position in memory of the data */
     b->memory = 1; /* content is in read-only memory */
     b->last_buf = 1; /* there will be no more buffers in the request */
 
     /* Sending the headers for the reply. */
     r->headers_out.status = NGX_HTTP_OK; /* 200 status code */
     /* Get the content length of the body. */
-    r->headers_out.content_length_n = sizeof(ngx_hello_world);
+    r->headers_out.content_length_n = sizeof(ngx_hello_world)-1;
     ngx_http_send_header(r); /* Send the headers */
 
     /* Send the body, and return the status code of the output filter chain. */


### PR DESCRIPTION
Content ended with terminating null character. This caused problems in web browsers. Firefox asked where to save file which is type of BIN. Chromium added to downloads. Both browsers decided this because content ended with null character, overriding text/plain content type.

Modified source to exclude null character and corresponding content-length header.